### PR TITLE
Fix backspace focus handling and mobile keyboard responsiveness

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
       return;
     }
 
-    const indexWithoutValue = inputValue.findIndex(i => !i);
+    const indexWithoutValue = newInputValue.findIndex(i => !i);
     setFocusIndex(indexWithoutValue);
     inputRefs[indexWithoutValue]?.current?.focus();
   };
@@ -188,7 +188,16 @@ export default function Home() {
         </KeyboardLine>
         <KeyboardLine>
         {thirdLine.map(k => (<KeyboardLetterItem key={k} onHandleClick={onClickLetterKeyboard} letter={k} validedLetterOfKeyboard={validateLetterOfKeyboard} />))}
-          <InputButton onClick={handleInputWordSubmit}>ENTER</InputButton>
+          <InputButton
+            type="button"
+            onClick={handleInputWordSubmit}
+            onTouchStart={(e) => {
+              e.preventDefault();
+              handleInputWordSubmit();
+            }}
+          >
+            ENTER
+          </InputButton>
         </KeyboardLine>
       </KeyboardContainer>
 

--- a/src/components/KeyboardLetter.tsx
+++ b/src/components/KeyboardLetter.tsx
@@ -20,5 +20,20 @@ export function KeyboardLetterItem({letter, validedLetterOfKeyboard, onHandleCli
         return styleLetterKeyBoardUnknown
       }
 
-  return <KeyboardLetter disabled={validedLetterOfKeyboard(letter) === LetterClassification.strong} onClick={() => onHandleClick(letter)} style={validedLetterOfKeboardStyle(letter)}>{letter}</KeyboardLetter>
+  const handlePress = (e: React.MouseEvent | React.TouchEvent) => {
+    e.preventDefault();
+    onHandleClick(letter);
+  };
+
+  return (
+    <KeyboardLetter
+      type="button"
+      disabled={validedLetterOfKeyboard(letter) === LetterClassification.strong}
+      onClick={handlePress}
+      onTouchStart={handlePress}
+      style={validedLetterOfKeboardStyle(letter)}
+    >
+      {letter}
+    </KeyboardLetter>
+  );
 }

--- a/styles.ts
+++ b/styles.ts
@@ -104,7 +104,8 @@ export const StyledInput = styled.input`
 `;
 
 export const KeyboardContainer = styled.div`
-
+  width: 100%;
+  overflow-x: hidden;
 `;
 
 export const KeyboardLine = styled.div`
@@ -124,7 +125,7 @@ export const KeyboardLetter = styled.button`
     font-weight: bold;
     color: #fff;
     @media (max-width: 480px) {
-      width: 32px;
+      width: 26px;
       height: 32px;
       margin: 2px;
       font-size: 12px;


### PR DESCRIPTION
## Summary
- keep input focus after using backspace to delete a letter
- handle touch events for keyboard letters and submit button to ensure responsiveness on mobile devices

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f9ce1e20832f9c327d5a08d26061