### PR TITLE
Add unit tests for KeyboardLetterItem component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "14.0.3",
@@ -23,6 +24,7 @@
     "eslint-config-next": "14.0.3",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/components/KeyboardLetter.tsx
+++ b/src/components/KeyboardLetter.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React from 'react';
 import { KeyboardLetter, styleLetterKeyBoardAlmost, styleLetterKeyBoardStrong, styleLetterKeyBoardSuccess, styleLetterKeyBoardUnknown } from '../../styles';
-import { LetterClassification } from '@/models';
+import { LetterClassification } from '../models';
 
 export function KeyboardLetterItem({letter, validedLetterOfKeyboard, onHandleClick}: {
     letter: string

--- a/tests/KeyboardLetterItem.test.tsx
+++ b/tests/KeyboardLetterItem.test.tsx
@@ -1,0 +1,30 @@
+import { test, expect } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { KeyboardLetterItem } from '../src/components/KeyboardLetter';
+import { styleLetterKeyBoardStrong, styleLetterKeyBoardSuccess } from '../styles';
+import { LetterClassification } from '../src/models';
+
+test('disables strong letters and applies strong style', () => {
+  const html = renderToStaticMarkup(
+    <KeyboardLetterItem
+      letter="A"
+      validedLetterOfKeyboard={() => LetterClassification.strong}
+      onHandleClick={() => {}}
+    />
+  );
+  expect(html).toMatch(/disabled=""/);
+  expect(html).toContain(`opacity:${styleLetterKeyBoardStrong.opacity}`);
+});
+
+test('applies success style for correct letters', () => {
+  const html = renderToStaticMarkup(
+    <KeyboardLetterItem
+      letter="B"
+      validedLetterOfKeyboard={() => LetterClassification.correct}
+      onHandleClick={() => {}}
+    />
+  );
+  expect(html).not.toContain('disabled=""');
+  expect(html).toContain(`background-color:${styleLetterKeyBoardSuccess.backgroundColor}`);
+});


### PR DESCRIPTION
## Summary
- configure tests to run with vitest
- convert KeyboardLetterItem test to vitest syntax
- drop obsolete TypeScript test build config

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8fd4aaf40832f9be8700fed5a70a6