### PR TITLE
test: expand KeyboardLetterItem coverage

### DIFF
--- a/tests/KeyboardLetterItem.test.tsx
+++ b/tests/KeyboardLetterItem.test.tsx
@@ -1,8 +1,14 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
 import { KeyboardLetterItem } from '../src/components/KeyboardLetter';
-import { styleLetterKeyBoardStrong, styleLetterKeyBoardSuccess } from '../styles';
+import {
+  styleLetterKeyBoardStrong,
+  styleLetterKeyBoardSuccess,
+  styleLetterKeyBoardAlmost,
+} from '../styles';
 import { LetterClassification } from '../src/models';
 
 test('disables strong letters and applies strong style', () => {
@@ -27,4 +33,49 @@ test('applies success style for correct letters', () => {
   );
   expect(html).not.toContain('disabled=""');
   expect(html).toContain(`background-color:${styleLetterKeyBoardSuccess.backgroundColor}`);
+});
+
+test('applies almost style for almost letters', () => {
+  const html = renderToStaticMarkup(
+    <KeyboardLetterItem
+      letter="C"
+      validedLetterOfKeyboard={() => LetterClassification.almost}
+      onHandleClick={() => {}}
+    />
+  );
+  expect(html).toContain(`background-color:${styleLetterKeyBoardAlmost.backgroundColor}`);
+});
+
+test('renders default style for unknown letters', () => {
+  const html = renderToStaticMarkup(
+    <KeyboardLetterItem
+      letter="D"
+      validedLetterOfKeyboard={() => LetterClassification.unknown}
+      onHandleClick={() => {}}
+    />
+  );
+  expect(html).toContain('style=""');
+});
+
+test('calls onHandleClick when button is pressed', () => {
+  const onHandleClick = vi.fn();
+  const container = document.createElement('div');
+
+  act(() => {
+    createRoot(container).render(
+      <KeyboardLetterItem
+        letter="E"
+        validedLetterOfKeyboard={() => LetterClassification.unknown}
+        onHandleClick={onHandleClick}
+      />
+    );
+  });
+
+  const button = container.querySelector('button') as HTMLButtonElement;
+
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  expect(onHandleClick).toHaveBeenCalledWith('E');
 });


### PR DESCRIPTION
## Summary
- broaden KeyboardLetterItem test coverage for additional letter classifications
- verify default styling and click handling of keyboard letters

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a900b9c114832f871a5796ab7359d5